### PR TITLE
verify: Allow to easily run the script

### DIFF
--- a/verification_script/verify.py
+++ b/verification_script/verify.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 
 if len(sys.argv) != 3:


### PR DESCRIPTION
imo it is convenient to run the script like `./verify.py input output`