### PR TITLE
Small changes to lower memory usage

### DIFF
--- a/verification_script/verify.py
+++ b/verification_script/verify.py
@@ -18,7 +18,7 @@ input_flights = dict()
 input_start_city = ''
 
 input_start_city = sys.intern(input.readline().rstrip())
-for l in input.readlines():
+for l in input:
     [f, t, d, p] = l.rstrip().split(' ') #From_city, To_city, Day, Price
     f = sys.intern(f)
     t = sys.intern(t)
@@ -38,7 +38,7 @@ output_price = 0
 calculated_price = 0
 
 output_price = int(output.readline().rstrip())
-for l in output.readlines():
+for l in output:
     [f, t, d, p] = l.rstrip().split(' ') #From_city, To_city, Day, Price
     f = sys.intern(f)
     t = sys.intern(t)

--- a/verification_script/verify.py
+++ b/verification_script/verify.py
@@ -32,6 +32,7 @@ for l in input:
         input_flights[(f, t, d)] = p
     input_cities.add(f)
     input_cities.add(t)
+input.close()
 
 output_flights = list()
 output_price = 0
@@ -50,6 +51,7 @@ for l in output:
         sys.exit(1)
     calculated_price += input_flights[(f, t, d)]
     output_flights.append((f, t, d))
+output.close()
 
 if calculated_price != output_price:
     print("Error: Price is not good")

--- a/verification_script/verify.py
+++ b/verification_script/verify.py
@@ -17,9 +17,11 @@ input_cities = set()
 input_flights = dict()
 input_start_city = ''
 
-input_start_city = input.readline().rstrip()
+input_start_city = sys.intern(input.readline().rstrip())
 for l in input.readlines():
     [f, t, d, p] = l.rstrip().split(' ') #From_city, To_city, Day, Price
+    f = sys.intern(f)
+    t = sys.intern(t)
     d = int(d)
     p = int(p)
 
@@ -38,6 +40,8 @@ calculated_price = 0
 output_price = int(output.readline().rstrip())
 for l in output.readlines():
     [f, t, d, p] = l.rstrip().split(' ') #From_city, To_city, Day, Price
+    f = sys.intern(f)
+    t = sys.intern(t)
     d = int(d)
     p = int(p)
 


### PR DESCRIPTION
Hi, this series lowers the memory usage to ~ half, but the script is approx 10% slower (probably due to the first patch).

Before:
	Command being timed: "./verify.py ../real_data/data_300.txt ../../../travelling-salesman-challenge-bests/data_300.txt.output"
	User time (seconds): 60.64
	System time (seconds): 8.13
	Percent of CPU this job got: 99%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 1:09.28
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 8896000

After:
	Command being timed: "./verify.py ../real_data/data_300.txt ../../../travelling-salesman-challenge-bests/data_300.txt.output"
	User time (seconds): 69.98
	System time (seconds): 4.48
	Percent of CPU this job got: 99%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 1:15.04
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 4268932